### PR TITLE
Exclude forks that are not behind their upstream

### DIFF
--- a/internal/synrk/synrk.go
+++ b/internal/synrk/synrk.go
@@ -54,11 +54,18 @@ func (c *concrete) GetForks(ctx context.Context) ([]*RepositoryWithDetails, erro
 
 	forksWithDetails := c.getReposDetail(ctx, forks)
 
-	sort.SliceStable(forksWithDetails, func(i, j int) bool {
-		return forksWithDetails[i].BehindBy > forksWithDetails[j].BehindBy
+	behindOrErrored := forksWithDetails[:0]
+	for _, f := range forksWithDetails {
+		if f.BehindBy > 0 || f.Error != nil {
+			behindOrErrored = append(behindOrErrored, f)
+		}
+	}
+
+	sort.SliceStable(behindOrErrored, func(i, j int) bool {
+		return behindOrErrored[i].BehindBy > behindOrErrored[j].BehindBy
 	})
 
-	return forksWithDetails, nil
+	return behindOrErrored, nil
 }
 
 func (c *concrete) SyncBranchWithUpstreamRepo(repo *RepositoryWithDetails) error {


### PR DESCRIPTION
Fixes #28

Only show forks with BehindBy > 0 or an error (e.g. parent branch deleted). Up-to-date forks are filtered out before the sort and never returned to the UI.

Generated with [Claude Code](https://claude.ai/code)