### PR TITLE
fix: surface sync errors in UI and fix nil resp dereference

### DIFF
--- a/internal/synrk/synrk.go
+++ b/internal/synrk/synrk.go
@@ -70,14 +70,13 @@ func (c *concrete) GetForks(ctx context.Context) ([]*RepositoryWithDetails, erro
 
 func (c *concrete) SyncBranchWithUpstreamRepo(repo *RepositoryWithDetails) error {
 	request := &github.RepoMergeUpstreamRequest{Branch: &repo.DefaultBranch}
-	res, resp, err := c.client.Repositories.MergeUpstream(context.Background(), repo.Owner, repo.Name, request)
-
-	if resp.StatusCode == http.StatusConflict {
-		return fmt.Errorf("couldn't merge with upstream %s branch due to conflict", res.GetBaseBranch())
-	}
+	_, resp, err := c.client.Repositories.MergeUpstream(context.Background(), repo.Owner, repo.Name, request)
 
 	if err != nil {
-		return fmt.Errorf("couldn't merge with upstream %s branch: %w", res.GetBaseBranch(), err)
+		if resp != nil && resp.StatusCode == http.StatusConflict {
+			return fmt.Errorf("couldn't merge with upstream %s branch due to conflict", repo.DefaultBranch)
+		}
+		return fmt.Errorf("couldn't merge with upstream %s branch: %w", repo.DefaultBranch, err)
 	}
 
 	return nil

--- a/internal/ui/item.go
+++ b/internal/ui/item.go
@@ -28,7 +28,7 @@ func (i item) Title() string {
 		return iconSynced + " " + titleStr
 	}
 
-	if !i.synced && i.repo.Error != nil {
+	if !i.synced && (i.repo.Error != nil || i.errMsg != "") {
 		return errorStyle.Render(iconSyncFailed + " " + titleStr)
 	}
 
@@ -47,6 +47,11 @@ func (i item) Description() string {
 	if i.repo.Error != nil {
 		reason := i.repo.Error.Error()
 		msg := base + " " + "fail to sync with" + " " + upstream + fmt.Sprintf("(%s)", reason)
+		return errorStyle.Copy().PaddingLeft(2).Render(msg)
+	}
+
+	if i.errMsg != "" {
+		msg := base + " fail to sync with " + upstream + fmt.Sprintf(" (%s)", i.errMsg)
 		return errorStyle.Copy().PaddingLeft(2).Render(msg)
 	}
 


### PR DESCRIPTION
Fixes two bugs that caused forks to appear un-synced with no feedback:

- `SyncBranchWithUpstreamRepo` accessed `resp.StatusCode` before checking `err`, panicking when `resp` is nil on network failures.
- `item.errMsg` was set on sync failure but never used in `Title()` or `Description()`, so failed syncs showed ● instead of ⨯ and the error reason was invisible.

Fixes #30

Generated with [Claude Code](https://claude.ai/code)